### PR TITLE
Fix (syntax): #2. fix syntax for enabling usage with typescript

### DIFF
--- a/dist/jasmine-disable-remaining.js
+++ b/dist/jasmine-disable-remaining.js
@@ -15,7 +15,7 @@
 
 const _ = require('lodash');
 
-module.exports = () => {
+module.exports = (() => {
     const defaultSuitesMatcherConfig = {
         callback: null,
 
@@ -406,4 +406,4 @@ module.exports = () => {
     }
 
     return JasmineDisableRemaining;
-}();
+})();

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "name": "jasmine-disable-remaining",
   "description": "Disable all remaining specs on the first spec failure.",
   "author": {
-    "email": "justmike-github.com@whatware.com",
-    "name": "justmike",
-    "url" : "https://github.com/justmike"
+    "email": "silvan.bregy@hazu.io",
+    "name": "silvan bregy",
+    "url" : "https://github.com/bregySilvan"
   },
   "bugs": {
     "email": "justmike-github.com@whatware.com",
-    "url" : "https://github.com/whatware/jasmine-disable-remaining/issues"
+    "url" : "https://github.com/bregySilvan/jasmine-disable-remaining/issues"
   },
   "bundledDependencies": [],
   "dependencies": {
@@ -33,7 +33,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/whatware/jasmine-disable-remaining/LICENSE"
+      "url": "https://github.com/bregySilvan/jasmine-disable-remaining/LICENSE"
     }
   ],
   "main": "dist/jasmine-disable-remaining.js",
@@ -44,7 +44,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/whatware/jasmine-disable-remaining.git"
+    "url": "git://github.com/bregySilvan/jasmine-disable-remaining.git"
   },
   "scripts": {}
 }


### PR DESCRIPTION
## Description 
Currently The module only can be used in typescript if main function is wrapped in parenthesis.
This pull Request does that.

This PR refers to #2 